### PR TITLE
Use ThoughtWire github as install location

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Online [documentation][doc] describes the library API (including the [annotated 
 
 Install the 'stompjs' module
 
-    $ npm install stompjs
+    $ npm install github:ThoughtWire/stomp-websocket
 
 In the node.js app, require the module with:
 


### PR DESCRIPTION
Initial install location is the unmaintained module. Better solution would be to get a different NPM module, but this is a decent stop-gap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thoughtwire/stomp-websocket/4)
<!-- Reviewable:end -->
